### PR TITLE
Add bower.json to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,5 @@
 
 src/
 docs/
+
+bower.json


### PR DESCRIPTION
See https://github.com/webpack/webpack/issues/1042

This ensures webpack will not use bower.json when react-widgets is installed from npm.
